### PR TITLE
Add branch numbering command

### DIFF
--- a/features/command_branch.feature
+++ b/features/command_branch.feature
@@ -1,0 +1,31 @@
+Feature: branch command
+
+  Background:
+    Given a mocked home directory
+
+  Scenario: Branch list is numbered
+    Given I am in a git repository
+    And a 1 byte file named "a.txt"
+    And I successfully run the following commands:
+      | git add a.txt |
+      | git commit -m "init" |
+    And I switch to git branch "branch_a"
+    And I switch to existing git branch "master"
+    And I switch to git branch "branch_b"
+    And I switch to existing git branch "master"
+    When I successfully run `scmpuff branch`
+    Then the stdout from "scmpuff branch" should contain "* [1] master"
+    And the stdout from "scmpuff branch" should contain "  [2] branch_a"
+    And the stdout from "scmpuff branch" should contain "  [3] branch_b"
+
+  Scenario: Detached HEAD is not numbered
+    Given I am in a git repository
+    And a 1 byte file named "a.txt"
+    And I successfully run the following commands:
+      | git add a.txt |
+      | git commit -m "init" |
+    And I successfully run `git checkout HEAD~0 --detach`
+    When I successfully run `scmpuff branch`
+    Then the stdout from "scmpuff branch" should contain "(HEAD detached"
+    And the stdout from "scmpuff branch" should contain "  [1] master"
+

--- a/features/command_init.feature
+++ b/features/command_init.feature
@@ -15,6 +15,7 @@ Feature: init command
   Scenario Outline: --aliases controls short aliases in output (default: yes)
     When I successfully run `scmpuff init <flags>`
     Then the output <should?> contain "alias gs='scmpuff_status'"
+    And  the output <should?> contain "alias gb='scmpuff_branch'"
     And  the output <should?> contain "alias ga='git add'"
     Examples:
       | flags              | should?    |
@@ -39,6 +40,7 @@ Feature: init command
     When I run `<shell>` interactively
       And I initialize scmpuff in `<shell>`
       And I type "type scmpuff_status"
+      And I type "type scmpuff_branch"
       And I type "type scmpuff_clear_vars"
       And I close the shell `<shell>`
     Then the output should not contain "not found"

--- a/internal/commands/branch/branch.go
+++ b/internal/commands/branch/branch.go
@@ -1,0 +1,75 @@
+package branch
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// CommandBranch generates the command handler for `scmpuff branch`
+func CommandBranch() *cobra.Command {
+	var branchCmd = &cobra.Command{
+		Use:   "branch",
+		Short: "List git branches with numbers",
+		Run: func(cmd *cobra.Command, args []string) {
+			out := gitBranchOutput()
+			lines := processBranches(out)
+			for i, line := range lines {
+				if i > 0 {
+					fmt.Println(line)
+				} else {
+					fmt.Print(line)
+					if len(lines) > 1 {
+						fmt.Println()
+					}
+				}
+			}
+		},
+	}
+	return branchCmd
+}
+
+func gitBranchOutput() []byte {
+	out, err := exec.Command("git", "branch", "--no-color").Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return out
+}
+
+func processBranches(out []byte) []string {
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	var head string
+	var others []string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "*") {
+			head = strings.TrimSpace(strings.TrimPrefix(line, "*"))
+		} else {
+			others = append(others, strings.TrimSpace(line))
+		}
+	}
+	var results []string
+	n := 1
+	if head != "" {
+		if strings.HasPrefix(head, "(") {
+			results = append(results, "* "+head)
+		} else {
+			results = append(results, fmt.Sprintf("* [%d] %s", n, head))
+			n++
+		}
+	}
+	for _, b := range others {
+		if b == "" {
+			continue
+		}
+		results = append(results, fmt.Sprintf("  [%d] %s", n, b))
+		n++
+	}
+	return results
+}

--- a/internal/commands/inits/data/aliases.sh
+++ b/internal/commands/inits/data/aliases.sh
@@ -1,4 +1,5 @@
 alias gs='scmpuff_status'
+alias gb='scmpuff_branch'
 alias ga='git add'
 alias gd='git diff'
 alias gl='git log'

--- a/internal/commands/inits/data/status_shortcuts.fish
+++ b/internal/commands/inits/data/status_shortcuts.fish
@@ -22,6 +22,10 @@ function scmpuff_status
     end
 end
 
+function scmpuff_branch
+    /usr/bin/env scmpuff branch $argv
+end
+
 function scmpuff_clear_vars
     set -l scmpuff_env_char "e"
     set -l scmpuff_env_vars (set -x | awk '{print $1}' | grep -E '^'$scmpuff_env_char'[0-9]+')

--- a/internal/commands/inits/data/status_shortcuts.sh
+++ b/internal/commands/inits/data/status_shortcuts.sh
@@ -37,6 +37,11 @@ scmpuff_status() {
 }
 
 
+scmpuff_branch() {
+  /usr/bin/env scmpuff branch "$@"
+}
+
+
 # Clear numbered env variables
 scmpuff_clear_vars() {
   local scmpuff_env_char="e"

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/mroth/scmpuff/internal/commands/branch"
 	"github.com/mroth/scmpuff/internal/commands/exec"
 	"github.com/mroth/scmpuff/internal/commands/expand"
 	"github.com/mroth/scmpuff/internal/commands/inits"
@@ -43,6 +44,7 @@ func main() {
 	puffCmd.AddCommand(inits.CommandInit())
 	puffCmd.AddCommand(exec.CommandExec())
 	puffCmd.AddCommand(expand.CommandExpand())
+	puffCmd.AddCommand(branch.CommandBranch())
 	puffCmd.AddCommand(status.CommandStatus())
 
 	puffCmd.Execute()


### PR DESCRIPTION
## Summary
- list and number Git branches via new `scmpuff branch` command
- expose `scmpuff_branch` helper in shell init scripts and alias it as `gb`
- test branch alias availability in `scmpuff init`
- add integration tests for branch command

## Testing
- `make features` *(fails: Command "zsh" not found)*