### PR TITLE
Fix branch colors

### DIFF
--- a/internal/commands/branch/branch.go
+++ b/internal/commands/branch/branch.go
@@ -47,7 +47,7 @@ func CommandBranch() *cobra.Command {
 }
 
 func gitBranchOutput() []byte {
-	out, err := exec.Command("git", "branch", "--color=always").Output()
+	out, err := exec.Command("git", "branch", "--color=never").Output()
 	if err != nil {
 		if err.Error() == "exit status 128" {
 			msg := "Not a git repository (or any of the parent directories)"
@@ -93,7 +93,7 @@ func process(out []byte) (string, []string) {
 			result = append(result, starBranch)
 			n++
 		} else {
-			b.WriteString(starLine + "\n")
+			b.WriteString(colorBranch + starLine + colorReset + "\n")
 		}
 	}
 	for _, name := range names {


### PR DESCRIPTION
## Summary
- stop using `git branch --color=always`
- color the active branch line ourselves in detached HEAD mode

## Testing
- `go test ./...`
- `bundle exec cucumber -s --tags='not @wip'` *(fails: Command "scmpuff" not found)*